### PR TITLE
Update lemon-graph formula to match version 1.3.1 of lemon in COIN-OR.

### DIFF
--- a/lemon-graph.rb
+++ b/lemon-graph.rb
@@ -2,19 +2,11 @@ require 'formula'
 
 class LemonGraph < Formula
   homepage 'http://lemon.cs.elte.hu/trac/lemon'
-  url 'http://lemon.cs.elte.hu/pub/sources/lemon-1.3.tar.gz'
-  sha1 'c833604b790e6f45d5cf8da304d9b23ba74eae6c'
+  url 'http://lemon.cs.elte.hu/pub/sources/lemon-1.3.1.tar.gz'
+  sha1 'b23d64c21b4b9088ad51e85316964a4a4138f82a'
 
   depends_on 'cmake' => :build
   depends_on 'glpk' => :recommended
-
-  fails_with :clang do
-    # http://lemon.cs.elte.hu/trac/lemon/ticket/471
-    build 500
-    cause <<-EOS.undent
-      dependent using declaration resolved to type without 'typename'
-      EOS
-  end
 
   def install
     args = std_cmake_args


### PR DESCRIPTION
In COIN-OR Lemon webpage (http://lemon.cs.elte.hu/trac/lemon/wiki/Downloads) there's already a new version for lemon (1.3.1) so the brew formula should be updated as well. Also the ticket http://lemon.cs.elte.hu/trac/lemon/ticket/471 is closed for this new version so the fragment code:

``` ruby
fails_with :clang do
  # http://lemon.cs.elte.hu/trac/lemon/ticket/471
  build 500
  cause <<-EOS.undent
    dependent using declaration resolved to type without 'typename'
    EOS
end
```

is not needed anymore.
